### PR TITLE
Code cleanup and test coverage bump

### DIFF
--- a/src/distancerasters/utils.py
+++ b/src/distancerasters/utils.py
@@ -202,20 +202,6 @@ def rasterize(
     return rv_array, affine
 
 
-def make_dir(path):
-    """Make directory.
-    Args:
-        path (str): absolute path for directory
-    Raise error if error other than directory exists occurs.
-    """
-    if path != "":
-        try:
-            os.makedirs(path)
-        except OSError as exception:
-            if exception.errno != errno.EEXIST:
-                raise
-
-
 def export_raster(raster, affine, path, out_dtype="float64", nodata=None):
 
     if not rasterio.dtypes.check_dtype(out_dtype):
@@ -239,7 +225,8 @@ def export_raster(raster, affine, path, out_dtype="float64", nodata=None):
 
     raster_out = np.array([raster.astype(out_dtype)])
 
-    make_dir(os.path.dirname(path))
+    if path != "":
+        os.makedirs(os.path.dirname(path), exist_ok=True)
 
     # write geotif file
     with rasterio.open(path, "w", **meta) as dst:

--- a/src/distancerasters/utils.py
+++ b/src/distancerasters/utils.py
@@ -233,12 +233,9 @@ def export_raster(raster, affine, path, out_dtype="float64", nodata=None):
         "driver": "GTiff",
         "height": raster.shape[0],
         "width": raster.shape[1],
-        # 'nodata': -1,
+        "nodata": nodata,
         # 'compress': 'lzw'
     }
-
-    if nodata is not None:
-        meta["nodata"] = nodata
 
     raster_out = np.array([raster.astype(out_dtype)])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,11 @@ def example_affine():
 
 @pytest.fixture
 def example_path():
-    return "tests/testdata/lorem/ipsum/dolor/amet"
+    path = "tests/testdata/lorem/ipsum/dolor/amet"
+    # remove any file at example_path that may have been created in previous tests
+    if os.path.isfile(path):
+        os.remove(path)
+    return path
 
 
 def test_get_affine_and_shape():
@@ -58,12 +62,21 @@ def test_bad_get_affine_and_shape():
         get_affine_and_shape((0, 0, 0, 0), "string")
 
 
-def test_rasterize(example_shape, example_raster):
+def test_rasterize(example_shape, example_raster, example_path):
+    
+    # pass shapely shape geometry to rasterize
     output_raster = rasterize(
         example_shape, pixel_size=0.5, bounds=example_shape.bounds
     )[0]
     assert (output_raster == example_raster).all
 
+    # same as above, with output path
+    output_raster = rasterize(
+        example_shape, pixel_size=0.5, bounds=example_shape.bounds, output=example_path
+    )[0]
+    # open raster written to example_path and make sure the data matches
+    with rasterio.open(example_path) as src:
+        assert (src.read() == example_raster).all
 
 def test_bad_rasterize(example_shape, example_affine):
 


### PR DESCRIPTION
- Increasing safety of example_path fixture in tests/test_utils.py for repeated testing (65b286b)
- Removing make_dir function in utils.py in favor of more modern os.makedirs function call (4e9c76b)
- New test for rasterize function to check if it calls export_raster correctly when given an output path (65b286b)
- Reducing "nodata" value handling in export_raster for cleaner code and a test coverage bump (9a022d9)

More detailed information can be found in the commit messages and comments. This PR brings our test coverage up to 98%