### PR TITLE
Convert main function to class

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,6 +2,8 @@ name: publish
 on:
   release:
     types: [published]
+    branches:
+      - master
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ MANIFEST
 *.egg-info
 htmlcov
 .coverage
-tests/
+tests/*
+!tests/*.py
 examples/*.tif

--- a/examples/adv_rasterization_example.py
+++ b/examples/adv_rasterization_example.py
@@ -8,7 +8,7 @@ a single feature layer
 
 import numpy as np
 from affine import Affine
-import distancerasters as dr
+from distancerasters as dr
 
 
 # paths to multiple vector datasets
@@ -51,8 +51,8 @@ def raster_conditional(rarray):
 
 distance_output_raster_path = "water_distance.tif"
 
-dist = dr.build_distance_array(water, affine=affine,
-                            output=distance_output_raster_path,
-                            conditional=raster_conditional)
+dist = dr.DistanceRaster(water, affine=affine,
+                         output_path=distance_output_raster_path,
+                         conditional=raster_conditional)
 
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -22,9 +22,9 @@ def raster_conditional(rarray):
     return (rarray == 1)
 
 # generate distance array and output to geotiff
-dist_array = dr.build_distance_array(rv_array, affine=affine,
-                     output="examples/linestrings_distance_raster.tif",
-                     conditional=raster_conditional)
+dist_array = dr.DistanceRaster(rv_array, affine=affine,
+                               output_path="examples/linestrings_distance_raster.tif",
+                               conditional=raster_conditional)
 
 # Output:
 #

--- a/src/distancerasters/__init__.py
+++ b/src/distancerasters/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-from .main import build_distance_array
+from .main import DistanceRaster
 from .utils import rasterize, export_raster

--- a/src/distancerasters/main.py
+++ b/src/distancerasters/main.py
@@ -69,7 +69,7 @@ class DistanceRaster(object):
         t_start = time.time()
         if tree_type == "kdtree":
             self.tree = cKDTree(data=np.array(np.where(self.conditional(self.raster_array))).T, leafsize=64)
-        print("Tree build time: {0} seconds".format(time.time() - t_start))
+        print("Tree build time: {0} seconds".format(round(time.time() - t_start, 4)))
 
 
     def _calculate_distance(self):
@@ -108,7 +108,7 @@ class DistanceRaster(object):
 
                 self.dist_array[r][c] = val
 
-        print("Distance calc run time: {0} seconds".format(round(time.time() - t_start, 2)))
+        print("Distance calc run time: {0} seconds".format(round(time.time() - t_start, 4)))
 
 
     def output_raster(self, output_path):

--- a/src/distancerasters/utils.py
+++ b/src/distancerasters/utils.py
@@ -9,29 +9,6 @@ from rasterstats.io import read_features
 import numpy as np
 
 
-def get_affine_and_shape(bounds, pixel_size):
-
-    try:
-        pixel_size = float(pixel_size)
-    except:
-        raise TypeError("Invalid pixel size (could not be converted to float)")
-
-    psi = 1 / pixel_size
-
-    xmin, ymin, xmax, ymax = bounds
-
-    xmin = math.floor(xmin * psi) / psi
-    ymin = math.floor(ymin * psi) / psi
-    xmax = math.ceil(xmax * psi) / psi
-    ymax = math.ceil(ymax * psi) / psi
-
-    shape = (int((ymax - ymin) * psi), int((xmax - xmin) * psi))
-
-    affine = Affine(pixel_size, 0, xmin, 0, -pixel_size, ymax)
-
-    return affine, shape
-
-
 def rasterize(
     vectors,
     layer=0,
@@ -184,6 +161,30 @@ def export_raster(raster, affine, path, out_dtype="float64", nodata=None):
         dst.write(raster_out)
 
 
+def get_affine_and_shape(bounds, pixel_size):
+    """Get affine and shape from bounds and pixel size
+    """
+    try:
+        pixel_size = float(pixel_size)
+    except:
+        raise TypeError("Invalid pixel size (could not be converted to float)")
+
+    psi = 1 / pixel_size
+
+    xmin, ymin, xmax, ymax = bounds
+
+    xmin = math.floor(xmin * psi) / psi
+    ymin = math.floor(ymin * psi) / psi
+    xmax = math.ceil(xmax * psi) / psi
+    ymax = math.ceil(ymax * psi) / psi
+
+    shape = (int((ymax - ymin) * psi), int((xmax - xmin) * psi))
+
+    affine = Affine(pixel_size, 0, xmin, 0, -pixel_size, ymax)
+
+    return affine, shape
+
+
 def convert_index_to_coords(index, affine):
     """convert index values to coordinates
 
@@ -207,9 +208,9 @@ def convert_index_to_coords(index, affine):
 
     pixel_size = affine[0]
     xmin = affine[2]
-    lon = xmin + pixel_size * (0.5 + c)
-
     ymax = affine[5]
+
+    lon = xmin + pixel_size * (0.5 + c)
     lat = ymax - pixel_size * (0.5 + r)
 
     return (lon, lat)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,9 +39,13 @@ def test_build_distance_array(example_raster_array, example_affine, example_path
 
     assert built_array[0][3] == math.sqrt(5)
 
+
+def test_build_distance_array_output(example_raster_array, example_affine, example_path):
+
     # Delete any previous test export, if it exists
     if os.path.isfile(example_path):
         os.remove(example_path)
+
     built_array = build_distance_array(
         example_raster_array, affine=example_affine, output=example_path
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import math
 from affine import Affine
 import pytest
 import numpy as np
-from distancerasters import build_distance_array
+from distancerasters import DistanceRaster
 from distancerasters.utils import calc_haversine_distance
 
 
@@ -25,7 +25,7 @@ def example_path():
 
 def test_build_distance_array(example_raster_array, example_affine, example_path):
 
-    built_array = build_distance_array(example_raster_array)
+    built_array = DistanceRaster(example_raster_array).dist_array
 
     # [1][1] was 1 in the passed array
     # The distance should be 0
@@ -46,8 +46,8 @@ def test_build_distance_array_output(example_raster_array, example_affine, examp
     if os.path.isfile(example_path):
         os.remove(example_path)
 
-    built_array = build_distance_array(
-        example_raster_array, affine=example_affine, output=example_path
+    built_array = DistanceRaster(
+        example_raster_array, affine=example_affine, output_path=example_path
     )
     # export_raster should have been called, and wrote output to example_path
     # perhaps we should more rigorously check if the exported raster is correct?
@@ -56,7 +56,7 @@ def test_build_distance_array_output(example_raster_array, example_affine, examp
 
 def test_build_distance_array_with_affine(example_raster_array, example_affine):
 
-    built_array = build_distance_array(example_raster_array, affine=example_affine)
+    built_array = DistanceRaster(example_raster_array, affine=example_affine).dist_array
 
     # Testing the same array elements as the last function did
 
@@ -76,19 +76,19 @@ def test_build_distance_array_with_affine(example_raster_array, example_affine):
 
 def test_bad_build_distance_array(example_raster_array):
     with pytest.raises(TypeError):
-        # Pass build_distance_array a 2D list
-        build_distance_array([[0, 1], [1, 0]])
+        # Pass DistanceRaster a 2D list
+        DistanceRaster([[0, 1], [1, 0]])
 
     with pytest.raises(TypeError):
-        # Pass build_distance_array a bad affine
-        build_distance_array(example_raster_array, affine="not_an_affine")
+        # Pass DistanceRaster a bad affine
+        DistanceRaster(example_raster_array, affine="not_an_affine")
 
     # perhaps this should be a more specific type of exception?
     with pytest.raises(Exception):
-        # Pass build_distance_array an output without an affine
-        build_distance_array(example_raster_array, output="just_output")
+        # Pass DistanceRaster an output without an affine
+        DistanceRaster(example_raster_array, output_path="just_output")
 
     # perhaps this should be a more specific type of exception?
     with pytest.raises(Exception):
-        # Pass build_distance_array an uncallable conditional
-        build_distance_array(example_raster_array, conditional="not_a_function")
+        # Pass DistanceRaster an uncallable conditional
+        DistanceRaster(example_raster_array, conditional="not_a_function")


### PR DESCRIPTION
This PR primarily converts the main interface into the package from a function (build_distance_array) to a class (DistanceRaster). 

This is not backwards compatible, but requires minimal changes

- use class name instead of function
- the output path kwarg is now "output_path" instead of "output"
- accessing the actual distance array now is done by accessing a class attribute (DistanceRaster.dist_array) rather than through the return of the build_distance_array function.