### PR TITLE
Add Python 3.10 to build and test GitHub Actions

### DIFF
--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -19,6 +19,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies ⚙️
       run: |
+        sudo apt-get update
+        sudo apt-get install libgdal-dev
         python -m pip install --upgrade pip
         pip install .
         pip install pytest pytest-cov shapely build geopandas
@@ -26,7 +28,7 @@ jobs:
       run: |
         pytest --cov=distancerasters
     - name: Coveralls 👖
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == '3.10'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: $COVERALLS_REPO_TOKEN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
With the release of [rasterio 1.3.0](https://github.com/rasterio/rasterio/releases/tag/1.3.0) today, distancerasters successfully builds in Python 3.10. This PR adds 3.10 to the matrix of Python versions to test in our "build" and "test" GitHub Actions workflows.