### PR TITLE
Drop Python 3.6 support, add Python 3.11 support

### DIFF
--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }} 🐍
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies ⚙️
@@ -28,7 +28,7 @@ jobs:
       run: |
         pytest --cov=distancerasters
     - name: Coveralls 👖
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.11'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: $COVERALLS_REPO_TOKEN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }} 🐍
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies ⚙️

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     rasterio
     fiona
     affine
-    scipy
+    scipy>=1.6.0
     rasterstats
 
 [options.packages.find]

--- a/src/distancerasters/main.py
+++ b/src/distancerasters/main.py
@@ -1,7 +1,7 @@
 import time
 import numpy as np
 from affine import Affine
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 from .utils import export_raster, convert_index_to_coords, calc_haversine_distance
 
 
@@ -63,12 +63,10 @@ class DistanceRaster(object):
 
     def _build_tree(self, tree_type='kdtree'):
         # kd-tree instance
-        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html
-        # As of SciPy v1.6.0, cKDTree is identical to KDTree, and the name is only kept for
-        # backward compatibility. See Issue #12 for more details.
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.KDTree.html
         t_start = time.time()
         if tree_type == "kdtree":
-            self.tree = cKDTree(data=np.array(np.where(self.conditional(self.raster_array))).T, leafsize=64)
+            self.tree = KDTree(data=np.array(np.where(self.conditional(self.raster_array))).T, leafsize=64)
         print("Tree build time: {0} seconds".format(round(time.time() - t_start, 4)))
 
 


### PR DESCRIPTION
Python 3.6 [is now EOL](https://devguide.python.org/versions/), and isn't available in the latest Ubuntu images that test our package. While it would be possible to continue testing it, I suggest we phase it out.

- Remove Python 3.6 tests from GitHub Actions test matrix
- Replace `cKDTree` with `KDTree` (see #12)
- Add Python 3.11 to GitHub Actions test matrix
- Update Actions used to build and test package

Closes #12 